### PR TITLE
fix(contracts): upgrade version stable 0.5.9 -> 0.5.8

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -33,7 +33,7 @@
     "eslint": "^9.9.0",
     "eslint-config-prettier": "^8.5.0",
     "ethers": "^6.8.0",
-    "fhevm": "^0.5.9",
+    "fhevm": "^0.5.8",
     "fhevmjs": "^0.5.2",
     "fs-extra": "^10.1.0",
     "globals": "^15.9.0",


### PR DESCRIPTION
Change version fhevm package 0.5.9 to 0.5.8 is to fix deployment error (check this with Zama team: open a issue)